### PR TITLE
Port-to-Minecraft-26.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ fun String.capitalized() =
     replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
 
 plugins {
-    id("dev.isxander.modstitch.base") version "0.8.2"
+    id("dev.isxander.modstitch.base") version "0.8.4"
 
     id("me.modmuss50.mod-publish-plugin") version "1.1.0"
 }
@@ -28,7 +28,11 @@ modstitch {
 
     // Alternatively use stonecutter.eval if you have a lot of versions to target.
     // https://stonecutter.kikugie.dev/stonecutter/guide/setup#checking-versions
-    javaVersion = if (stonecutter.eval(mcVersion, ">1.20.4")) 21 else 17
+    javaVersion = when {
+        stonecutter.eval(mcVersion, ">=26.1") -> 25
+        stonecutter.eval(mcVersion, ">1.20.4") -> 21
+        else -> 17
+    }
 
     // If parchment doesn't exist for a version, yet you can safely
     // omit the "deps.parchment" property from your versioned gradle.properties
@@ -63,6 +67,7 @@ modstitch {
                 "1.21.8" -> 64
                 "1.21.10" -> 69
                 "1.21.11" -> 75
+                "26.1" -> 84
                 else -> throw IllegalArgumentException("Please store the resource pack version for ${property("deps.minecraft")} in build.gradle.kts! https://minecraft.wiki/w/Pack_format")
             }.toString())
             put("yacl_version", "${property("deps.yacl")}-${loader}")
@@ -73,7 +78,7 @@ modstitch {
     loom {
         // It's not recommended to store the Fabric Loader version in properties.
         // Make sure it's up to date.
-        fabricLoaderVersion = "0.17.3"
+        fabricLoaderVersion = if (stonecutter.eval(mcVersion, ">=26.1")) "0.18.4" else "0.17.3"
 
         // Configure loom like normal in this block.
         configureLoom {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,7 +19,8 @@ pluginManagement {
 }
 
 plugins {
-    id("dev.kikugie.stonecutter") version "0.8.2"
+    id("dev.kikugie.stonecutter") version "0.8.3"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 stonecutter {
@@ -40,12 +41,12 @@ stonecutter {
         mc("1.21.8", loaders = listOf("fabric", "neoforge"))
         mc("1.21.10", loaders = listOf("fabric", "neoforge"))
         mc("1.21.11", loaders = listOf("fabric", "neoforge"))
+        mc("26.1", loaders = listOf("fabric", "neoforge"))
 
         // This is the default target.
         // https://stonecutter.kikugie.dev/stonecutter/guide/setup#settings-settings-gradle-kts
-        vcsVersion = "1.21.4-fabric"
+        vcsVersion = "26.1-fabric"
     }
 }
 
 rootProject.name = "Disable Elytra Outside The End"
-

--- a/src/main/java/io/github/timtaran/deote/commands/DeoteCommands.java
+++ b/src/main/java/io/github/timtaran/deote/commands/DeoteCommands.java
@@ -17,11 +17,11 @@ import net.minecraft.commands.Commands;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 
-//? if <=1.21.10 {
-import static org.apache.commons.lang3.StringUtils.startsWithIgnoreCase;
-//?} else {
-/*import net.minecraft.server.permissions.Permissions;
+//? if >1.21.10 {
+import net.minecraft.server.permissions.Permissions;
 import org.apache.commons.lang3.Strings;
+//?} else {
+/*import static org.apache.commons.lang3.StringUtils.startsWithIgnoreCase;
 *///?}
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,10 +34,10 @@ import java.util.Collection;
  */
 public class DeoteCommands {
     private static boolean startsWith(String str, String prefix) {
-        //? if <=1.21.10 {
-        return startsWithIgnoreCase(str, prefix);
+        //? if >1.21.10 {
+        return Strings.CI.startsWith(str, prefix);
         //?} else {
-        /*return Strings.CI.startsWith(str, prefix);
+        /*return startsWithIgnoreCase(str, prefix);
         *///?}
     }
     public static final SuggestionProvider<CommandSourceStack> SUGGEST_PARAM_NAME =
@@ -99,10 +99,10 @@ public class DeoteCommands {
     private static Collection<String> getAllDimensions(MinecraftServer minecraftServer) {
         Collection<String> dimensions = new ArrayList<>();
         for (ServerLevel level : minecraftServer.getAllLevels()) {
-            //? if <=1.21.10 {
-             dimensions.add(level.dimension().location().toString());
+            //? if >1.21.10 {
+             dimensions.add(level.dimension().identifier().toString());
             //?} else {
-            /*dimensions.add(level.dimension().identifier().toString());
+            /*dimensions.add(level.dimension().location().toString());
             *///?}
         }
         return dimensions;
@@ -185,10 +185,10 @@ public class DeoteCommands {
     public static void registerCommands(CommandDispatcher<CommandSourceStack> dispatcher) {
         dispatcher.register(
                 Commands.literal("deote")
-                        //? if <=1.21.10 {
-                         .requires(source -> source.hasPermission(3))
+                        //? if >1.21.10 {
+                         .requires(source -> source.permissions().hasPermission(Permissions.COMMANDS_ADMIN))
                         //?} else {
-                        /*.requires(source -> source.permissions().hasPermission(Permissions.COMMANDS_ADMIN))
+                        /*.requires(source -> source.hasPermission(3))
                         *///?}
 
                         .executes(context -> {

--- a/src/main/java/io/github/timtaran/deote/compat/CuriosCompat.java
+++ b/src/main/java/io/github/timtaran/deote/compat/CuriosCompat.java
@@ -1,4 +1,4 @@
-//? if neoforge && <= 1.21.4 {
+//? if neoforge && <= 1.21.4 && <26.1 {
 /*package io.github.timtaran.deote.compat;
 
 import net.minecraft.resources.ResourceLocation;

--- a/src/main/java/io/github/timtaran/deote/platform/PlatformEntrypoint.java
+++ b/src/main/java/io/github/timtaran/deote/platform/PlatformEntrypoint.java
@@ -45,7 +45,11 @@ public class PlatformEntrypoint implements ModInitializer {
     public void onInitialize() {
         DisableElytraOutsideTheEnd.initialize();
 
-        PayloadTypeRegistry.playS2C().register(ConfigSyncS2CPacket.TYPE, ConfigSyncS2CPacket.STREAM_CODEC);
+        //? if >=26.1 {
+        PayloadTypeRegistry.clientboundPlay().register(ConfigSyncS2CPacket.TYPE, ConfigSyncS2CPacket.STREAM_CODEC);
+        //?} else {
+        /*PayloadTypeRegistry.playS2C().register(ConfigSyncS2CPacket.TYPE, ConfigSyncS2CPacket.STREAM_CODEC);
+        *///?}
 
         ServerPlayConnectionEvents.JOIN.register((handler, sender, server) ->
                 // Fabric server doesn't care if client doesn't have channel so we're not catching any exceptions here
@@ -108,10 +112,10 @@ public class PlatformEntrypoint {
         };
         //?} elif neoforge {
         /*return switch (
-                //? if <=1.21.8 {
-                FMLEnvironment.dist
+                //? if >1.21.8 {
+                FMLEnvironment.getDist()
                 //?} else {
-                /^FMLEnvironment.getDist()
+                /^FMLEnvironment.dist
                 ^///?}
                 ) {
             case CLIENT -> Dist.CLIENT;
@@ -127,10 +131,10 @@ public class PlatformEntrypoint {
     public static void resendConfig(MinecraftServer server) {
 
         for (ServerPlayer player : server.getPlayerList().getPlayers()) {
-            //? if <1.21.9 {
-            if (!server.isSingleplayerOwner(player.getGameProfile()))
+            //? if >=1.21.9 {
+            if (!server.isSingleplayerOwner(player.nameAndId()))
             //?} else {
-            /*if (!server.isSingleplayerOwner(player.nameAndId()))
+            /*if (!server.isSingleplayerOwner(player.getGameProfile()))
             *///?}
                 sendConfigSyncPacket(player, DeoteConfig.getInstance());
         }

--- a/src/main/java/io/github/timtaran/deote/util/ConfigHelper.java
+++ b/src/main/java/io/github/timtaran/deote/util/ConfigHelper.java
@@ -26,10 +26,11 @@ public class ConfigHelper {
      */
     public static boolean isAllowedDimension(DeoteConfig deoteConfig, Level level) {
         return deoteConfig.dimensionList.contains(
+                //? if >1.21.10 {
+                level.dimension().identifier().toString()
+                //?}
                 //? if <= 1.21.10 {
-                level.dimension().location().toString()
-                //?} else {
-                /*level.dimension().identifier().toString()
+                /*level.dimension().location().toString()
                  *///?}
         );
     }

--- a/src/main/java/io/github/timtaran/deote/util/DeoteIdentifier.java
+++ b/src/main/java/io/github/timtaran/deote/util/DeoteIdentifier.java
@@ -7,10 +7,10 @@
 package io.github.timtaran.deote.util;
 
 import io.github.timtaran.deote.DisableElytraOutsideTheEnd;
-//? if <=1.21.10 {
-import net.minecraft.resources.ResourceLocation;
+//? if >1.21.10 {
+import net.minecraft.resources.Identifier;
 //?} else {
-/*import net.minecraft.resources.Identifier;
+/*import net.minecraft.resources.ResourceLocation;
  *///?}
 
 /**
@@ -19,13 +19,13 @@ import net.minecraft.resources.ResourceLocation;
  * @author timtaran
  */
 public class DeoteIdentifier {
-    //? if <=1.21.10 {
-    public static ResourceLocation get(String path) {
-        return ResourceLocation.fromNamespaceAndPath(DisableElytraOutsideTheEnd.MOD_ID, path);
+    //? if >1.21.10 {
+    public static Identifier get(String path) {
+        return Identifier.fromNamespaceAndPath(DisableElytraOutsideTheEnd.MOD_ID, path);
     }
     //?} else {
-     /*public static Identifier get(String path) {
-         return Identifier.fromNamespaceAndPath(DisableElytraOutsideTheEnd.MOD_ID, path);
+     /*public static ResourceLocation get(String path) {
+         return ResourceLocation.fromNamespaceAndPath(DisableElytraOutsideTheEnd.MOD_ID, path);
      }
     *///?}
 }

--- a/src/main/java/io/github/timtaran/deote/util/FallFlyingPreventer.java
+++ b/src/main/java/io/github/timtaran/deote/util/FallFlyingPreventer.java
@@ -14,7 +14,7 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 
-//? if neoforge && <= 1.21.4 {
+//? if neoforge && <= 1.21.4 && <26.1 {
 /*import net.neoforged.neoforge.items.IItemHandler;
 import io.github.timtaran.deote.compat.CuriosCompat;
 *///?}
@@ -49,7 +49,7 @@ public class FallFlyingPreventer {
             }
             //?}
 
-            //? if neoforge && <= 1.21.4 {
+            //? if neoforge && <= 1.21.4 && <26.1 {
             /*IItemHandler capability = livingEntity.getCapability(CuriosCompat.CURIOS_INVENTORY);
             if (capability != null) {
                 if (ConfigHelper.isAllowedItem(capability.getStackInSlot(1))) // chest
@@ -59,7 +59,7 @@ public class FallFlyingPreventer {
         }
 
         if (GlobalStorage.deoteConfig.warningMessageEnabled && entity instanceof ServerPlayer player)
-            player.displayClientMessage(Component.literal(warningMessage), true);
+            player.sendSystemMessage(Component.literal(warningMessage), true);
 
         return true;
     }

--- a/src/main/java/io/github/timtaran/deote/util/TextUtils.java
+++ b/src/main/java/io/github/timtaran/deote/util/TextUtils.java
@@ -44,8 +44,16 @@ public class TextUtils {
     }
 
     public static Style styleCommandText(Style style, String commandText, String shownText) {
-        //? if <1.21.7 {
+        //? if >=1.21.7 {
         return style.withClickEvent(
+                        new ClickEvent.SuggestCommand(
+                                commandText
+                        ))
+                .withHoverEvent(
+                        new HoverEvent.ShowText(
+                                Component.literal(shownText)));
+        //?} else {
+        /*return style.withClickEvent(
                         new ClickEvent(
                                 ClickEvent.Action.SUGGEST_COMMAND,
                                 commandText
@@ -55,14 +63,6 @@ public class TextUtils {
                                 HoverEvent.Action.SHOW_TEXT,
                                 Component.literal(shownText))
                 );
-        //?} else {
-        /*return style.withClickEvent(
-                        new ClickEvent.SuggestCommand(
-                                commandText
-                        ))
-                .withHoverEvent(
-                        new HoverEvent.ShowText(
-                                Component.literal(shownText)));
         *///?}
     }
 }

--- a/versions/26.1-fabric/gradle.properties
+++ b/versions/26.1-fabric/gradle.properties
@@ -1,0 +1,8 @@
+modstitch.platform=fabric-loom
+
+deps.minecraft=26.1
+deps.fabric_api=0.140.3+26.1
+deps.yacl=3.9.2+26.1
+deps.modmenu=18.0.0-alpha.8
+
+pub.stableMC=26.1

--- a/versions/26.1-neoforge/gradle.properties
+++ b/versions/26.1-neoforge/gradle.properties
@@ -1,0 +1,7 @@
+modstitch.platform=moddevgradle
+
+deps.minecraft=26.1
+deps.neoforge=26.1.0.0-alpha.12+snapshot-7
+deps.yacl=3.9.2+26.1
+
+pub.stableMC=26.1

--- a/versions/current
+++ b/versions/current
@@ -1,1 +1,1 @@
-1.21.4-fabric
+26.1-fabric


### PR DESCRIPTION
## Summary

Ports the mod to Minecraft 26.1 on both Fabric and NeoForge.

## Changes

- add `26.1-fabric` and `26.1-neoforge` Stonecutter targets
- update build tooling for 26.1 with Java 25, Gradle 9.4.0, and Foojay toolchain resolution
- add 26.1 metadata/dependency values and switch the default target to `26.1-fabric`
- update cross-version source branches for 26.1 API changes:
  - `Identifier` / `identifier()`
  - Fabric `PayloadTypeRegistry.clientboundPlay()`
  - newer command permissions handling
  - newer click/hover event APIs
  - newer player system message call
- keep older Curios compat gated to older NeoForge targets

## Verification

- `gradlew.bat :26.1-fabric:build --no-parallel`
- `gradlew.bat :26.1-neoforge:build --no-parallel`
- `gradlew.bat build --no-parallel`
